### PR TITLE
Set "language: generic" for all builds in the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,16 @@ language: python
 matrix:
     include:
         - os: linux
+          language: generic
           env: PYTHON="3.4" MINICONDA_OS="Linux"
         - os: linux
+          language: generic
           env: PYTHON="3.5" MINICONDA_OS="Linux"
         - os: osx
+          language: generic
           env: PYTHON="3.4" MINICONDA_OS="MacOSX"
         - os: osx
+          language: generic
           env: PYTHON="3.5" MINICONDA_OS="MacOSX"
 
 before_install:


### PR DESCRIPTION
I'm pretty sure this is what broke travis builds for OS X